### PR TITLE
LPS-104395 - Remove elementClasses in favor of style prop

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PreviewButton/PreviewButton.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PreviewButton/PreviewButton.es.js
@@ -40,7 +40,6 @@ class PreviewButton extends Component {
 
 		return (
 			<ClayButton
-				elementClasses={'btn-secondary'}
 				events={{
 					click: this._handleButtonClicked.bind(this)
 				}}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PublishButton/PublishButton.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/PublishButton/PublishButton.es.js
@@ -28,7 +28,6 @@ class PublishButton extends Component {
 
 		return (
 			<ClayButton
-				elementClasses={'btn-secondary'}
 				events={{
 					click: this._handleButtonClicked.bind(this)
 				}}


### PR DESCRIPTION
Note, that these classes weren't needed in the first place since the "style" prop is taking priority. `btn-default` wasn't actually applying any styles since `btn-primary` and `btn-link` were priority since they were declared via the style prop(`btn-primary` is the default value).