### PR TITLE
LPS 122074 | Removing IE11 macros and paths from master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormFields.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormFields.macro
@@ -183,31 +183,12 @@ definition {
 	}
 
 	macro editText {
-		var browserType = PropsUtil.get("browser.type");
+		Pause(locator1 = "1000");
 
-		if ("${browserType}" == "internetexplorer") {
-			Type(
-				key_fieldName = "${fieldName}",
-				locator1 = "FormFields#TEXT_FIELD",
-				value1 = "");
-
-			KeyPress(
-				key_fieldName = "${fieldName}",
-				locator1 = "FormFields#TEXT_FIELD",
-				value1 = "${fieldValue}");
-
-			Pause(locator1 = "5000");
-
-			takeScreenshot();
-		}
-		else {
-			Pause(locator1 = "1000");
-
-			Type(
-				key_fieldName = "${fieldName}",
-				locator1 = "FormFields#TEXT_FIELD",
-				value1 = "${fieldValue}");
-		}
+		Type(
+			key_fieldName = "${fieldName}",
+			locator1 = "FormFields#TEXT_FIELD",
+			value1 = "${fieldValue}");
 	}
 
 	macro editTextAlt {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdminNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdminNavigator.macro
@@ -166,12 +166,7 @@ definition {
 	}
 
 	macro gotoViewEntries {
-		if (IsElementNotPresent(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS")) {
-			AssertElementPresent(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS_IE");
-		}
-		else {
-			AssertElementPresent(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS");
-		}
+		AssertElementPresent(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS");
 
 		LexiconEntry.gotoEllipsisMenuItem(menuItem = "View Entries");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/LexiconEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LexiconEntry.macro
@@ -57,13 +57,7 @@ definition {
 		if ("${browserType}" == "chrome") {
 			MetalComponent.waitForManagementBar();
 		}
-
-		if ("${browserType}" == "internetexplorer") {
-			Click(locator1 = "Button#PLUS_IE");
-		}
-		else {
-			Click(locator1 = "Button#PLUS");
-		}
+		Click(locator1 = "Button#PLUS");
 	}
 
 	macro gotoAddDropdownMenuItem {
@@ -89,14 +83,7 @@ definition {
 	}
 
 	macro gotoEllipsisMenuItem {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click.waitForMenuToggleJSClick(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS_IE");
-		}
-		else {
-			Click.waitForMenuToggleJSClick(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS");
-		}
+		Click.waitForMenuToggleJSClick(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS");
 
 		WaitForLiferayEvent.initializeLiferayEventLog();
 
@@ -159,14 +146,7 @@ definition {
 	}
 
 	macro gotoHeaderMenuItem {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click.clickNoMouseOver(locator1 = "Icon#HEADER_VERTICAL_ELLIPSIS_IE");
-		}
-		else {
-			Click(locator1 = "Icon#HEADER_VERTICAL_ELLIPSIS");
-		}
+		Click(locator1 = "Icon#HEADER_VERTICAL_ELLIPSIS");
 
 		MenuItem.click(menuItem = "${menuItem}");
 	}
@@ -180,13 +160,7 @@ definition {
 	macro openEntryMenu {
 		var browserType = PropsUtil.get("browser.type");
 
-		if ("${browserType}" == "internetexplorer") {
-			Click.waitForMenuToggleJSClick(
-				key_rowEntry = "${rowEntry}",
-				locator1 = "Icon#ROW_VERTICAL_ELLIPSIS_IE");
-		}
-
-		else if ("${browserType}" == "safari") {
+		if ("${browserType}" == "safari") {
 			Click.waitForMenuToggleJSClick(
 				key_rowEntry = "${rowEntry}",
 				locator1 = "Icon#ROW_VERTICAL_ELLIPSIS_SAFARI");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ManagementBar.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ManagementBar.macro
@@ -31,16 +31,7 @@ definition {
 	}
 
 	macro clickInfo {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click.clickAt(locator1 = "Icon#INFO_IE");
-
-			Pause(locator1 = "3000");
-		}
-		else {
-			Click.clickNoMouseOver(locator1 = "Icon#INFO");
-		}
+		Click.clickNoMouseOver(locator1 = "Icon#INFO");
 	}
 
 	macro clickSelectAllCheckbox {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/MessageboardsThread.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MessageboardsThread.macro
@@ -1014,16 +1014,7 @@ definition {
 
 		AssertElementPresent(locator1 = "MessageBoards#THREAD_LIST_VIEWS");
 
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			AssertElementPresent(
-				key_rowEntry = "${threadSubject}",
-				locator1 = "Icon#ROW_VERTICAL_ELLIPSIS_IE");
-		}
-		else {
-			AssertElementPresent(locator1 = "MessageBoards#THREAD_LIST_ACTIONS");
-		}
+		AssertElementPresent(locator1 = "MessageBoards#THREAD_LIST_ACTIONS");
 
 		AssertClick.assertPartialTextClickAt(
 			locator1 = "MessageBoards#THREAD_LIST_THREAD",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
@@ -1,18 +1,9 @@
 definition {
 
 	macro _clickAddPortlet {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click.javaScriptClick(
-				key_portletName = "${portletName}",
-				locator1 = "ControlMenuAddPanel#ADD_PORTLET_LINK");
-		}
-		else {
-			Click.clickNoWaitForVisible(
-				key_portletName = "${portletName}",
-				locator1 = "ControlMenuAddPanel#ADD_PORTLET_LINK");
-		}
+		Click.clickNoWaitForVisible(
+			key_portletName = "${portletName}",
+			locator1 = "ControlMenuAddPanel#ADD_PORTLET_LINK");
 	}
 
 	macro addDuplicatePG {
@@ -154,14 +145,7 @@ definition {
 	macro clickPortletPlusIconPG {
 		var browserType = PropsUtil.get("browser.type");
 		var key_portletName = "${portletName}";
-
-		if ("${browserType}" == "internetexplorer") {
-			Click.javaScriptClick(locator1 = "Portlet#ICON_PLUS_SIGN");
-
-			AssertVisible(locator1 = "Portlet#ICON_PLUS_SIGN");
-		}
-
-		else if ("${browserType}" == "safari") {
+		if ("${browserType}" == "safari") {
 			Click.javaScriptClick(locator1 = "Portlet#ICON_PLUS_SIGN");
 
 			AssertVisible(locator1 = "Portlet#ICON_PLUS_SIGN");
@@ -273,13 +257,7 @@ definition {
 			var key_portletName = "${portletName}";
 			var browserType = PropsUtil.get("browser.type");
 
-			if ("${browserType}" == "internetexplorer") {
-				Click.javaScriptClick(locator1 = "Portlet#SPECIFIC_BORDERLESS_ELLIPSIS_ICON");
-
-				AssertVisible(locator1 = "Portlet#SPECIFIC_BORDERLESS_ELLIPSIS_ICON");
-			}
-
-			else if ("${browserType}" == "safari") {
+			if ("${browserType}" == "safari") {
 				Click.javaScriptClick(locator1 = "Portlet#SPECIFIC_BORDERLESS_ELLIPSIS_ICON");
 
 				AssertVisible(locator1 = "Portlet#SPECIFIC_BORDERLESS_ELLIPSIS_ICON");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchPortlets.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchPortlets.macro
@@ -5,18 +5,9 @@ definition {
 	 */
 
 	macro _clickAddPortlet {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click.javaScriptClick(
-				key_portletName = "${portletName}",
-				locator1 = "Search#ADD_PORTLET_LINK");
-		}
-		else {
-			Click.clickNoWaitForVisible(
-				key_portletName = "${portletName}",
-				locator1 = "Search#ADD_PORTLET_LINK");
-		}
+		Click.clickNoWaitForVisible(
+			key_portletName = "${portletName}",
+			locator1 = "Search#ADD_PORTLET_LINK");
 	}
 
 	macro addWidgets {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -150,12 +150,7 @@ definition {
 
 		var browserType = PropsUtil.get("browser.type");
 
-		if ("${browserType}" == "internetexplorer") {
-			AssertElementPresent(locator1 = "Button#PLUS_IE");
-		}
-		else {
-			AssertElementPresent(locator1 = "Button#PLUS");
-		}
+		AssertElementPresent(locator1 = "Button#PLUS");
 
 		AssertConsoleTextNotPresent(value1 = "Please configure tunneling.servlet.shared.secret");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/UserBar.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/UserBar.macro
@@ -8,14 +8,7 @@ definition {
 			Click.waitForMenuToggleJSClick(locator1 = "UserBar#USER_AVATAR_TOGGLE");
 		}
 		else {
-			var browserType = PropsUtil.get("browser.type");
-
-			if ("${browserType}" == "internetexplorer") {
-				Click.waitForPersonalMenuJSClick(locator1 = "UserBar#USER_AVATAR_ICON_IE");
-			}
-			else {
-				Click.waitForPersonalMenuJSClick(locator1 = "UserBar#USER_AVATAR_ICON");
-			}
+			Click.waitForPersonalMenuJSClick(locator1 = "UserBar#USER_AVATAR_ICON");
 		}
 
 		AssertVisible(locator1 = "UserBar#USER_AVATAR_DROPDOWN_PORTAL_OPEN");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/Vocabulary.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/Vocabulary.macro
@@ -236,14 +236,7 @@ definition {
 			Button.click(button = "Add Vocabulary");
 		}
 		else {
-			var browserType = PropsUtil.get("browser.type");
-
-			if ("${browserType}" == "internetexplorer") {
-				Click(locator1 = "NavNested#NAV_NESTED_PLUS_IE");
-			}
-			else {
-				Click(locator1 = "NavNested#NAV_NESTED_PLUS");
-			}
+			Click(locator1 = "NavNested#NAV_NESTED_PLUS");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/fragment/FragmentsAdminNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/fragment/FragmentsAdminNavigator.macro
@@ -1,20 +1,13 @@
 definition {
 
 	macro gotoAddCollection {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click(locator1 = "NavNested#NAV_NESTED_PLUS_IE");
+		if (IsElementPresent(locator1 = "NavNested#NAV_NESTED_PLUS")) {
+			Click(locator1 = "NavNested#NAV_NESTED_PLUS");
 		}
 		else {
-			if (IsElementPresent(locator1 = "NavNested#NAV_NESTED_PLUS")) {
-				Click(locator1 = "NavNested#NAV_NESTED_PLUS");
-			}
-			else {
-				Button.click(button = "New");
+			Button.click(button = "New");
 
-				MenuItem.click(menuItem = "Collection");
-			}
+			MenuItem.click(menuItem = "Collection");
 		}
 	}
 
@@ -35,14 +28,7 @@ definition {
 	}
 
 	macro gotoExportCollection {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click(locator1 = "NavNested#NAV_NESTED_ELLIPSIS_IE");
-		}
-		else {
-			Click.waitForMenuToggleJSClick(locator1 = "NavNested#NAV_NESTED_ELLIPSIS");
-		}
+		Click.waitForMenuToggleJSClick(locator1 = "NavNested#NAV_NESTED_ELLIPSIS");
 
 		DropdownMenuItem.click(menuItem = "Export");
 
@@ -52,18 +38,11 @@ definition {
 	}
 
 	macro gotoImportCollection {
-		var browserType = PropsUtil.get("browser.type");
-
-		if ("${browserType}" == "internetexplorer") {
-			Click(locator1 = "NavNested#NAV_NESTED_ELLIPSIS_IE");
+		if (IsElementPresent(locator1 = "NavNested#NAV_NESTED_ELLIPSIS")) {
+			Click.waitForMenuToggleJSClick(locator1 = "NavNested#NAV_NESTED_ELLIPSIS");
 		}
 		else {
-			if (IsElementPresent(locator1 = "NavNested#NAV_NESTED_ELLIPSIS")) {
-				Click.waitForMenuToggleJSClick(locator1 = "NavNested#NAV_NESTED_ELLIPSIS");
-			}
-			else {
-				Button.click(button = "New");
-			}
+			Button.click(button = "New");
 		}
 
 		DropdownMenuItem.click(menuItem = "Import");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/sitepage/SitePages.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/sitepage/SitePages.macro
@@ -466,16 +466,9 @@ definition {
 			}
 		}
 
-		if ("${browserType}" == "internetexplorer") {
-			Click(
-				key_pageName = "${pageName}",
-				locator1 = "SitePages#LIST_GROUP_ITEM_ELLIPSIS_ICON_IE");
-		}
-		else {
-			Click(
-				key_pageName = "${pageName}",
-				locator1 = "SitePages#LIST_GROUP_ITEM_ELLIPSIS_ICON");
-		}
+		Click(
+			key_pageName = "${pageName}",
+			locator1 = "SitePages#LIST_GROUP_ITEM_ELLIPSIS_ICON");
 
 		MenuItem.click(menuItem = "${menuItem}");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -479,11 +479,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>PLUS_IE</td>
-	<td>//a[contains(@class,'nav-btn-monospaced')] | //button[contains(@class,'nav-btn-monospaced')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>POST</td>
 	<td>//div[@class='button-holder']/button[contains(@id,'MicroblogsPortlet') and not (contains(@class,'disabled'))]/span[contains(.,'Post')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
@@ -209,11 +209,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>INFO_IE</td>
-	<td>//button[contains(@aria-label,'info-circle-open') or contains(@id,'OpenContextualSidebar')] | //*[@data-qa-id='infoButton']</td>
-	<td></td>
-</tr>
-<tr>
 	<td>INFO_ACTIVE</td>
 	<td>//*[contains(@class,'active') and contains(@class,'open') and @data-qa-id='infoButton']</td>
 	<td></td>
@@ -330,11 +325,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>BODY_VERTICAL_ELLIPSIS_IE</td>
-	<td>//div[contains(@class,'portlet') and contains(@class,'container')]//a[contains(@class,'icon-monospaced')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>DEPOT_LANGUAGES_ELLIPSIS</td>
 	<td>//tr[contains(.,'${key_language}')]//*[name()='svg'][contains(@class,'icon-ellipsis')]</td>
 	<td></td>
@@ -347,11 +337,6 @@
 <tr>
 	<td>HEADER_VERTICAL_ELLIPSIS</td>
 	<td>//*[@data-qa-id='header']//a[span/*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>HEADER_VERTICAL_ELLIPSIS_IE</td>
-	<td>//*[@data-qa-id='header']//a[@title='Options']</td>
 	<td></td>
 </tr>
 <tr>
@@ -392,11 +377,6 @@
 <tr>
 	<td>ROW_VERTICAL_ELLIPSIS_2</td>
 	<td>xPath=(//*[@data-qa-id='row' and contains(.,'${key_rowEntry}')]//a[span/*[name()='svg'][contains(@class,'icon-ellipsis')]])[2]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ROW_VERTICAL_ELLIPSIS_IE</td>
-	<td>//*[@data-qa-id='row' and contains(.,'${key_rowEntry}')]//a[contains(@class,'icon-monospaced')]/span</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavNested.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/NavNested.path
@@ -19,11 +19,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>NAV_NESTED_ELLIPSIS_IE</td>
-	<td>//*[contains(@class,'nav-nested')]//*[contains(@class,'dropdown-toggle')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>NAV_NESTED_LINK</td>
 	<td>//ul[contains(@class,'nav-nested')]//li//*[normalize-space()='${key_navNested}']</td>
 	<td></td>
@@ -31,11 +26,6 @@
 <tr>
 	<td>NAV_NESTED_PLUS</td>
 	<td>//ul[contains(@class,'nav-nested')]//*[*[name()='svg'][contains(@class,'icon-plus')]]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>NAV_NESTED_PLUS_IE</td>
-	<td>//*[contains(@class,'nav-nested')]//a[contains(@class,'btn')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePages.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sitepages/SitePages.path
@@ -55,11 +55,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>LIST_GROUP_ITEM_ELLIPSIS_ICON_IE</td>
-	<td>xpath=(//li[contains(.,'${key_pageName}')]//button[contains(@class,'dropdown-toggle')])[2]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>LIST_GROUP_ITEM_ENTRY_TITLE</td>
 	<td>//li[contains(@class,'list-group-item')][contains(.,'${key_pageName}')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
@@ -39,11 +39,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>USER_AVATAR_ICON_IE</td>
-	<td>//span[@class='user-avatar-link']//span[contains(@class,'sticker-overlay')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>USER_AVATAR_ICON_PNG</td>
 	<td>portal/screenshots/user/user_avatar_icon.png</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/permissions/Permissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/permissions/Permissions.testcase
@@ -66,13 +66,6 @@ definition {
 			Navigator.gotoPage(pageName = "Blogs Page");
 		}
 
-		var browserType = PropsUtil.get("browser.type");
-		var key_portletName = "Blogs";
-
-		if (("${browserType}" == "internetexplorer") && (IsElementNotPresent(locator1 = "Home#PORTLET"))) {
-			Refresh();
-		}
-
 		BlogsConfiguration.viewNoPermissionPG();
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122073
https://issues.liferay.com/browse/LPS-122074
1. Removing macros with `"${browserType}" == "internetexplorer"` from master branch
2. Removing paths with `"IE_11"` from master branch