### PR TITLE
LRQA-60526 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Alert.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Alert.macro
@@ -81,10 +81,6 @@ definition {
 
 	macro viewSuccessMessage {
 		VerifyElementPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
-
-		if (IsElementPresent(locator1 = "Button#CLOSE_MESSAGE")) {
-			Click(locator1 = "Button#CLOSE_MESSAGE");
-		}
 	}
 
 	macro viewSuccessMessageText {


### PR DESCRIPTION
**Description**
Trying to close the alert message causes test flakiness due to timing issues. Also, closing the alert message is not required for a global macro to view the alert message. Therefore, we're simply removing the close button action in the macro. In general, a waitFor function or some other workaround is advised instead of using strict assertions in macros which are mostly used for test setup purposes. Component QA teams will follow up on non-acceptance tests affected by this change.

**Test Plan**
- Validate ci:test:acceptance passes or failures are unrelated

**JIRA Ticket**
https://issues.liferay.com/browse/LRQA-60526